### PR TITLE
allow tests to run on other platforms, ensure report is always created, resolve task name issue

### DIFF
--- a/Biosimulations_copasi/core.py
+++ b/Biosimulations_copasi/core.py
@@ -93,23 +93,19 @@ def exec_combine_archive(archive_file, out_dir):
             try:
                 data_model = copasi.CRootContainer.addDatamodel()
             except BaseException:
-                data_model = copasi.CRootContainer.getUndefinedFunction()
+                data_model = copasi.CRootContainer.getUndefinedFunction() # TODO: this makes no sense whatsoever, the undefined kinetic law will not let you import sed-ml, better to bail here
+
+            # the sedml_importer will only import one time course task
             data_model.importSEDML(sedml_path)
 
             report = create_time_course_report(data_model)
-            # Run all Tasks
+
+            # Run all Tasks - TODO: this code only runs the time course task
             task_name_index = 0
             for task_index in range(0, len(data_model.getTaskList())):
-                task = data_model.getTaskList().get(task_index)
+                task = data_model.getTaskList().get(task_index) # TODO: since this code does only run the time course task, it would be better to just retrieve it directly using data_model.getTask('Time-Course')
                 # Get Name and Class of task as string
-                task_str = str(task)
-                try:
-                    # Get name of Task
-                    task_name = task_str.split('"')[1]
-                except IndexError:
-                    # Get Class name if Task name is not present
-                    task_name = task_str.split("'")[1].split("*")[0]
-                    task_name = task_name[:len(task_name) - 1]
+                task_name = task.getObjectName()
                 # Set output file for the task
                 if task_name == 'Time-Course':
                     task.setScheduled(True)

--- a/Biosimulations_copasi/utils.py
+++ b/Biosimulations_copasi/utils.py
@@ -14,7 +14,14 @@ def create_time_course_report(dataModel):
     # time.
     reports = dataModel.getReportDefinitionList()
     # create a report definition object
-    report = reports.createReportDefinition("Time-Course", "Output for timecourse")
+    report = reports.createReportDefinition("Time-Course", "Output for timecourse") 
+    
+    count = 1
+    while report is None: 
+        # this is expected, if there is already a report present with that name
+        report = reports.createReportDefinition(f'Time-Course_{count}', "Output for timecourse")
+        count += 1
+
     # set the task type for the report definition to timecourse
     report.setTaskType(copasi.CTaskEnum.Task_timeCourse)
     # we don't want a table

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -10,7 +10,11 @@ try:
     from Biosimulations_utils.simulator.testing import SimulatorValidator
 except ModuleNotFoundError:
     pass
-import capturer
+try:
+    import capturer # not available on all platforms
+except ModuleNotFoundError:
+    capturer = None
+    pass
 
 import Biosimulations_copasi
 from Biosimulations_copasi import __main__
@@ -18,6 +22,7 @@ from Biosimulations_copasi import __main__
 try:
     import docker
 except ModuleNotFoundError:
+    docker = None
     pass
 import os
 import numpy
@@ -40,6 +45,7 @@ class CliTestCase(unittest.TestCase):
             with __main__.App(argv=['--help']) as app:
                 app.run()
 
+    @unittest.skipIf(capturer is None, 'capturer not available')
     def test_version(self):
         with __main__.App(argv=['-v']) as app:
             with capturer.CaptureOutput(merged=False, relay=False) as captured:


### PR DESCRIPTION
The task name issue was caused in the new version of COPASI, as a new analysis task ('Time-Course Sensitivities') was added to the language bindings in the latest version of COPASI. Since the code resolved names, by mangling the representation string, rather than calling the underlying function, it would fail for you before. 

Also fixed an issue with the report generation that would fail, in the case that another report with the same name already existed. 